### PR TITLE
feat: add support for the Lute runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  lune-zune-test:
+  http-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +30,14 @@ jobs:
           sudo mv zune /usr/local/bin/zune
           rm zune.zip
 
+      - name: Install Lute
+        run: |
+          curl -f -L "https://github.com/luau-lang/lute/releases/download/v1.0.0/lute-linux-x86_64.zip" -o lute.zip
+          unzip -j lute.zip
+          chmod +x lute
+          sudo mv lute /usr/local/bin/lute
+          rm lute.zip
+
       - name: Run Lune CI
         working-directory: .
         run: lune run test
@@ -37,3 +45,7 @@ jobs:
       - name: Run Zune CI
         working-directory: .
         run: zune run test
+
+      - name: Run Lute CI
+        working-directory: .
+        run: lute run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
-#pesde
+# lock packages
 pesde.lock
+package-lock.json
 
 # env files
 .env
@@ -10,3 +11,8 @@ pesde.lock
 # packages
 lune_packages/
 luau_packages/
+node_modules/
+
+# vitepress
+docs/.vitepress/dist
+docs/.vitepress/cache

--- a/.luaurc
+++ b/.luaurc
@@ -1,15 +1,15 @@
 {
-    "languageMode": "strict", 
-    "globals": [
-        "warn"
-    ], 
-    "aliases": {
-        "pesde": "lune_packages/", 
-        "std": "~/.lute/typedefs/0.1.0/std", 
-        "lune": "~/.lune/.typedefs/0.10.4/", 
-        "lint": "~/.lute/typedefs/0.1.0/lint", 
-        "nova": "/home/wiz/projects/nova/ci/src/", 
-        "c": "/home/wiz/projects/nova/ci/", 
-        "lute": "~/.lute/typedefs/0.1.0/lute"
-    }
+  "aliases": {
+    "c": "",
+    "lint": "~/.lute/typedefs/0.1.0/lint",
+    "lune": "~/.lune/.typedefs/0.10.4/",
+    "lute": "~/.lute/typedefs/0.1.0/lute",
+    "nova": "/home/wiz/projects/nova/ci/src/",
+    "pesde": "lune_packages/",
+    "std": "~/.lute/typedefs/0.1.0/std"
+  },
+  "globals": [
+    "warn"
+  ],
+  "languageMode": "strict"
 }

--- a/.luaurc
+++ b/.luaurc
@@ -1,15 +1,1 @@
-{
-  "aliases": {
-    "c": "",
-    "lint": "~/.lute/typedefs/0.1.0/lint",
-    "lune": "~/.lune/.typedefs/0.10.4/",
-    "lute": "~/.lute/typedefs/0.1.0/lute",
-    "nova": "/home/wiz/projects/nova/ci/src/",
-    "pesde": "lune_packages/",
-    "std": "~/.lute/typedefs/0.1.0/std"
-  },
-  "globals": [
-    "warn"
-  ],
-  "languageMode": "strict"
-}
+{"languageMode":"strict","aliases":{"pesde":"lune_packages/","std":"~/.lute/typedefs/0.1.0/std","c":"/home/wiz/projects/nova/ci/","lint":"~/.lute/typedefs/0.1.0/lint","nova":"./ci/src/","lune":"~/.lune/.typedefs/0.10.4/","lute":"~/.lute/typedefs/0.1.0/lute"},"globals":["warn"]}

--- a/.luaurc
+++ b/.luaurc
@@ -1,11 +1,15 @@
 {
-  "aliases": {
-    "c": "",
-    "lune": "~/.lune/.typedefs/0.10.4/",
-    "pesde": "lune_packages/"
-  },
-  "globals": [
-    "warn"
-  ],
-  "languageMode": "strict"
+    "languageMode": "strict", 
+    "globals": [
+        "warn"
+    ], 
+    "aliases": {
+        "pesde": "lune_packages/", 
+        "std": "~/.lute/typedefs/0.1.0/std", 
+        "lune": "~/.lune/.typedefs/0.10.4/", 
+        "lint": "~/.lute/typedefs/0.1.0/lint", 
+        "nova": "/home/wiz/projects/nova/ci/src/", 
+        "c": "/home/wiz/projects/nova/ci/", 
+        "lute": "~/.lute/typedefs/0.1.0/lute"
+    }
 }

--- a/.luaurc
+++ b/.luaurc
@@ -1,1 +1,15 @@
-{"languageMode":"strict","aliases":{"pesde":"lune_packages/","std":"~/.lute/typedefs/0.1.0/std","c":"/home/wiz/projects/nova/ci/","lint":"~/.lute/typedefs/0.1.0/lint","nova":"./ci/src/","lune":"~/.lune/.typedefs/0.10.4/","lute":"~/.lute/typedefs/0.1.0/lute"},"globals":["warn"]}
+{
+  "aliases": {
+    "c": "/home/wiz/projects/nova/ci/",
+    "lint": "~/.lute/typedefs/0.1.0/lint",
+    "lune": "~/.lune/.typedefs/0.10.4/",
+    "lute": "~/.lute/typedefs/0.1.0/lute",
+    "nova": "./ci/src/",
+    "pesde": "lune_packages/",
+    "std": "~/.lute/typedefs/0.1.0/std"
+  },
+  "globals": [
+    "warn"
+  ],
+  "languageMode": "strict"
+}

--- a/.lune/start.luau
+++ b/.lune/start.luau
@@ -1,4 +1,19 @@
 local process = require("@lune/process")
+local serde = require("../src/libs/serde")
+local fs = require("../src/libs/fs")
+
+local luaurcPath = process.cwd .. "/.luaurc"
+local luaurcjson = fs.readFile(luaurcPath)
+local decode = serde.decode("json", luaurcjson)
+
+if not decode.aliases then
+    decode.aliases = {}
+end
+
+decode.aliases.c = process.cwd .. "ci/"
+
+local encode = serde.encode("json", decode, true)
+fs.writeFile(luaurcPath, encode)
 
 local running = process.exec("lune", { "run", "src/index" }, { stdio = "inherit", cwd = "ci" })
 

--- a/.lune/test.luau
+++ b/.lune/test.luau
@@ -1,4 +1,19 @@
 local process = require("@lune/process")
+local serde = require("../src/libs/serde")
+local fs = require("../src/libs/fs")
+
+local luaurcPath = process.cwd .. "/.luaurc"
+local luaurcjson = fs.readFile(luaurcPath)
+local decode = serde.decode("json", luaurcjson)
+
+if not decode.aliases then
+    decode.aliases = {}
+end
+
+decode.aliases.c = process.cwd .. "ci/"
+
+local encode = serde.encode("json", decode, true)
+fs.writeFile(luaurcPath, encode)
 
 local running = process.exec("lune", { "run", "tests/lune" }, { stdio = "inherit", cwd = "ci" })
 

--- a/.lute/start.luau
+++ b/.lute/start.luau
@@ -1,4 +1,19 @@
 local process = require("@lute/process")
+local serde = require("../src/libs/serde")
+local fs = require("../src/libs/fs")
+
+local luaurcPath = process.cwd() .. "/.luaurc"
+local luaurcjson = fs.readFile(luaurcPath)
+local decode = serde.decode("json", luaurcjson)
+
+if not decode.aliases then
+    decode.aliases = {}
+end
+
+decode.aliases.c = process.cwd() .. "/ci/"
+
+local encode = serde.encode("json", decode, true)
+fs.writeFile(luaurcPath, encode)
 
 local running = process.run( { "lute", "run", "src/index" }, { stdio = "inherit", cwd = "ci" })
 

--- a/.lute/start.luau
+++ b/.lute/start.luau
@@ -1,0 +1,7 @@
+local process = require("@lute/process")
+
+local running = process.run( { "lute", "run", "src/index" }, { stdio = "inherit", cwd = "ci" })
+
+if not running.ok then 
+    print(running.stderr)
+end

--- a/.lute/test.luau
+++ b/.lute/test.luau
@@ -1,0 +1,7 @@
+local process = require("@lute/process")
+
+local running = process.run({"lune", "run", "tests/lune"}, { stdio = "inherit", cwd = "ci" })
+
+if not running.ok then 
+    print(running.stderr)
+end

--- a/.zune/start.luau
+++ b/.zune/start.luau
@@ -1,4 +1,4 @@
-local process = require("@lute/process")
+local process = zune.process
 local serde = require("../src/libs/serde")
 local fs = require("../src/libs/fs")
 
@@ -15,7 +15,12 @@ decode.aliases.c = process.cwd() .. "/ci/"
 local encode = serde.encode("json", decode, true)
 fs.writeFile(luaurcPath, encode)
 
-local running = process.run( { "lute", "run", "tests/lute" }, { stdio = "inherit", cwd = "ci" })
+local running = process.run("zune", { "run", `src/index` }, {
+        stdin = "inherit",
+        stdout = "inherit",
+        stderr = "inherit",
+        cwd = "ci"
+    })
 
 if not running.ok then 
     print(running.stderr)

--- a/.zune/test.luau
+++ b/.zune/test.luau
@@ -1,4 +1,4 @@
-local process = require("@lute/process")
+local process = zune.process
 local serde = require("../src/libs/serde")
 local fs = require("../src/libs/fs")
 
@@ -15,7 +15,12 @@ decode.aliases.c = process.cwd() .. "/ci/"
 local encode = serde.encode("json", decode, true)
 fs.writeFile(luaurcPath, encode)
 
-local running = process.run( { "lute", "run", "tests/lute" }, { stdio = "inherit", cwd = "ci" })
+local running = process.run("zune", { "run", `tests/zune` }, {
+        stdin = "inherit",
+        stdout = "inherit",
+        stderr = "inherit",
+        cwd = "ci"
+    })
 
 if not running.ok then 
     print(running.stderr)

--- a/README.md
+++ b/README.md
@@ -21,32 +21,30 @@
 
 - [Table of Contents](#table-of-contents)
 - [Installation \& Usage](#installation--usage)
-  - [Manual Installation](#manual-installation)
-    - [Usage](#usage)
-  - [Install a boilerplate](#install-a-boilerplate)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Manual Setup](#manual-setup)
 - [Core Features](#core-features)
-- [Route Definition](#route-definition)
 - [Routing Conventions](#routing-conventions)
 - [Middleware Chaining](#middleware-chaining)
 
 ## Installation & Usage
 
-### Manual Installation
+### Installation
 
-Manually install Nova via the Pesde package manager:
+Install Nova via the Pesde package manager:
 
 ```sh
 pesde add bizwiz3/nova
 pesde install
 ```
 
-#### Usage
+### Usage
 
-In your root project or `src/` directory, create your entry file.
+#### Manual Setup
 
-*Example:* `index.luau`
-
-*Paste the code below:*
+1. Create a `src/` directory in your project root.
+2. Create an entry file (e.g., `index.luau`) inside `src/` with the following code:
 
 ```lua
 local Nova = require("@path/to/nova")
@@ -56,13 +54,33 @@ local app = Nova.new(8080)
 app:listen() -- To run the server
 ```
 
-### Install a boilerplate
+3. Create an `app/` directory inside `src/`. This directory will house your routes.
+4. To create a route, add a `route.luau` file inside a directory within `app/`. The directory name becomes the base route.
 
-Installing a boilerplate for much easier setup
+For example, to create a route at `/`, create `src/app/route.luau`:
 
-```sh
-pesde x bizwiz/nova_setup
-pesde install
+```lua
+local Nova = require("@path/to/nova")
+
+local App = {}
+
+function App.Get()
+    return Nova.response.json({ msg = "Hello, Nova" })
+end
+
+return App
+```
+
+The module must export properties named after HTTP methods: `Get`, `Post`, `Put`, `Patch`, and `Delete`. You can define them as functions:
+
+```lua
+local App = {}
+
+App.Get = function()
+    return Nova.response.json({ msg = "Hello, Nova" })
+end
+
+return App
 ```
 
 ## Core Features
@@ -74,73 +92,33 @@ pesde install
 - **Environment Management:** Automatic `.env` loading and process injection.
 - **Integrated Logger:** Colored terminal output for request monitoring and debugging.
 
-## Route Definition
-
-Nova organizes routes by folder. To create a route at `/`, you must create an `app/` directory first in your root project or `src/` directory.
-
-Create a luau file inside the `app/` directory and name it `route.luau`.
-
-*Should look like this:*
-
-```sh
-project-dir/
-├── src/
-    ├── app/
-    |   └── route.luau
-    └── index.luau    
-```
-
-*Or like this*
-
-```sh
-project-dir/
-├── app/
-|    └── route.luau
-└── index.luau
-```
-
-*Paste the code below inside the `route.luau`:*
-
-```lua
-local Nova = require("@path/to/nova")
-
-local App = {}
-
-function App.Get()
-    return Nova.response({ msg = "Hello, Nova" })
-end
-
-return App
-```
-
-The Module name `App` itself does not matter, but it must have `Get`, `Post`, etc. as its public function.
-
 ## Routing Conventions
 
 Nova follows a predictable mapping from the filesystem to the URL path:
 
 | Path | Filesystem Map |
 | :--- | :--- |
-| **/** | `app/route.luau` |
-| **/users** | `app/users/route.luau` |
-| **/posts/:id** | `app/posts/[id]/route.luau` |
+| **/** | `src/app/route.luau` |
+| **/users** | `src/app/users/route.luau` |
+| **/posts/:id** | `src/app/posts/[id]/route.luau` |
 
 ## Middleware Chaining
 
 Utilize the `chain` helper to apply logic sequentially before a request reaches the final handler:
 
 ```lua
+-- route.luau
 local Nova = require("@path/to/nova")
 
 local function validate(req, next)
     if not req.headers["x-api-key"] then
-        return Nova.response({ error = "Forbidden" }, { status = 403 })
+        return Nova.response.json({ error = "Forbidden" }, { status = 403 })
     end
     next()
 end
 
 Route.Get = Nova.chain({ validate }, function(req)
-    return Nova.response({ data = "Authorized access" })
+    return Nova.response.json({ data = "Authorized access" })
 end)
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
         <img src="https://github.com/BizWiz3/nova/actions/workflows/ci.yml/badge.svg">
     </a>
     <h3>
-        A filesystem-based web framework for Luau runtimes, with out-of-the-box support for <a href="https://lune-org.github.io/docs/" alt="Lune Runtime">Lune</a> and <a href="https://zune.sh/" alt="Lune Runtime">Zune</a>.
+        A filesystem-based web framework for Luau runtimes, with out-of-the-box support for <a href="https://lune-org.github.io/docs/" alt="Lune Runtime">Lune</a> and <a href="https://zune.sh/" alt="Zune Runtime">Zune</a>.
     </h3>
 </div> 
 

--- a/ci/.luaurc
+++ b/ci/.luaurc
@@ -1,12 +1,12 @@
 {
-    "languageMode": "strict", 
-    "globals": [
-        "warn"
-    ], 
-    "aliases": {
-        "pesde": "lune_packages/", 
-        "c": "/home/wiz/projects/nova/ci/", 
-        "nova": "/home/wiz/projects/nova/src/", 
-        "lune": "~/.lune/.typedefs/0.10.4/"
-    }
+  "aliases": {
+    "c": "/home/wiz/projects/nova/ci/",
+    "lune": "~/.lune/.typedefs/0.10.4/",
+    "nova": "/home/wiz/projects/nova/src/",
+    "pesde": "lune_packages/"
+  },
+  "globals": [
+    "warn"
+  ],
+  "languageMode": "strict"
 }

--- a/ci/.luaurc
+++ b/ci/.luaurc
@@ -1,11 +1,12 @@
 {
-  "aliases": {
-    "c": "/home/wiz/projects/nova/ci/",
-    "lune": "~/.lune/.typedefs/0.10.4/",
-    "pesde": "lune_packages/"
-  },
-  "globals": [
-    "warn"
-  ],
-  "languageMode": "strict"
+    "languageMode": "strict", 
+    "globals": [
+        "warn"
+    ], 
+    "aliases": {
+        "pesde": "lune_packages/", 
+        "c": "/home/wiz/projects/nova/ci/", 
+        "nova": "/home/wiz/projects/nova/src/", 
+        "lune": "~/.lune/.typedefs/0.10.4/"
+    }
 }

--- a/ci/.luaurc
+++ b/ci/.luaurc
@@ -1,1 +1,12 @@
-{"languageMode":"strict","aliases":{"pesde":"lune_packages/","lune":"~/.lune/.typedefs/0.10.4/","c":"/home/wiz/projects/nova/ci/","nova":"/home/wiz/projects/nova/src/"},"globals":["warn"]}
+{
+  "aliases": {
+    "c": "/home/wiz/projects/nova/ci/",
+    "lune": "~/.lune/.typedefs/0.10.4/",
+    "nova": "../src/",
+    "pesde": "lune_packages/"
+  },
+  "globals": [
+    "warn"
+  ],
+  "languageMode": "strict"
+}

--- a/ci/.luaurc
+++ b/ci/.luaurc
@@ -1,12 +1,1 @@
-{
-  "aliases": {
-    "c": "/home/wiz/projects/nova/ci/",
-    "lune": "~/.lune/.typedefs/0.10.4/",
-    "nova": "/home/wiz/projects/nova/src/",
-    "pesde": "lune_packages/"
-  },
-  "globals": [
-    "warn"
-  ],
-  "languageMode": "strict"
-}
+{"languageMode":"strict","aliases":{"pesde":"lune_packages/","lune":"~/.lune/.typedefs/0.10.4/","c":"/home/wiz/projects/nova/ci/","nova":"/home/wiz/projects/nova/src/"},"globals":["warn"]}

--- a/ci/src/app/[file]/route.luau
+++ b/ci/src/app/[file]/route.luau
@@ -1,6 +1,6 @@
-local Nova = require("../../../../src/index")
-local fs = require("../../../../src/libs/fs")
-local process = require("../../../../src/libs/process")
+local Nova = require("@nova/index")
+local fs = require("@nova/libs/fs")
+local process = require("@nova/libs/process")
 
 local SimpleWeb = {}
 

--- a/ci/src/app/route.luau
+++ b/ci/src/app/route.luau
@@ -1,4 +1,4 @@
-local Nova = require("../../../src/index")
+local Nova = require("@nova/index")
 
 local Home = {}
 

--- a/ci/src/app/users/[id]/route.luau
+++ b/ci/src/app/users/[id]/route.luau
@@ -1,4 +1,4 @@
-local Nova = require("../../../../../src/index")
+local Nova = require("@nova/index")
 
 local UserId = {}
 

--- a/ci/src/app/users/route.luau
+++ b/ci/src/app/users/route.luau
@@ -1,4 +1,4 @@
-local Nova = require("../../../../src/index")
+local Nova = require("@nova/index")
 
 local Users = {}
 

--- a/ci/src/index.luau
+++ b/ci/src/index.luau
@@ -1,4 +1,4 @@
-local Nova = require("../../src/index")
+local Nova = require("@nova/index")
 
 local app = Nova.new(8080)
 

--- a/ci/tests/lute.luau
+++ b/ci/tests/lute.luau
@@ -1,0 +1,28 @@
+local process = require("@lute/process")
+
+local TEST_FILES = { "post", "get", "put", "delete" }
+local failed = false
+
+print("\27[36mStarting Nova Test Suite...\27[0m")
+
+for _, name in TEST_FILES do
+    print(`Running {name}... `)
+    
+    local result = process.run({"lune", "run", `tests/{name}` })
+
+    if result.ok then
+        print("\27[32mPASSED\27[0m")
+    else
+        print("\27[31mFAILED\27[0m")
+        print(`\27[33m{result.stderr}\27[0m`)
+        failed = true
+    end
+end
+
+if failed then
+    print("\nTest Suite Failed")
+    process.exit(1)
+else
+    print("\nTest Suite Successful")
+    process.exit(0)
+end

--- a/src/libs/fs/init.luau
+++ b/src/libs/fs/init.luau
@@ -8,6 +8,8 @@ local function getAdapter(): Types.FsAdapter
         return require("@self/lune")
     elseif runtime == "zune" then
         return require("@self/zune")
+    elseif runtime == "luau" then
+        return require("@self/lute")
     else
         error(`Unsupported Runtime: "{runtime}"`)
     end

--- a/src/libs/fs/lune.luau
+++ b/src/libs/fs/lune.luau
@@ -1,8 +1,5 @@
 local fs = require("@lune/fs")
-local luau = require("@lune/luau")
 local Types = require("./types")
-
-local moduleCache = {}
 
 local LuneFs = {} :: Types.FsAdapter
 
@@ -28,76 +25,6 @@ end
 
 function LuneFs.metadata(path: string)
     return fs.metadata(path) :: any
-end
-
--- Helper to normalize and join paths properly
-local function resolvePath(baseDir: string, target: string): string
-    -- If it's not a relative path, return as is (for absolute or @lune paths)
-    if not target:find("^%.") then
-        return target
-    end
-
-    local segments = baseDir:split("/")
-    -- Remove the last empty segment if baseDir ended in /
-    if segments[#segments] == "" then table.remove(segments) end
-
-    for _, segment in target:split("/") do
-        if segment == ".." then
-            table.remove(segments)
-        elseif segment ~= "." and segment ~= "" then
-            table.insert(segments, segment)
-        end
-    end
-
-    return table.concat(segments, "/")
-end
-
-function LuneFs.loadModule(path: string): any
-    -- 1. Ensure we have a clean path without double .luau
-    local cleanPath = path:gsub("%.luau$", ""):gsub("%.lua$", "")
-    local fullPath = cleanPath .. ".luau"
-
-    if moduleCache[fullPath] then
-        return moduleCache[fullPath]
-    end
-
-    -- 2. Read the file with explicit error handling
-    local readSuccess, source = pcall(fs.readFile, fullPath)
-    if not readSuccess then
-        -- This will tell you if it's looking for 'route.luau.luau' or a wrong path
-        error(`[LuneFs] File not found: {fullPath}`)
-    end
-
-    local bytecode = luau.compile(source)
-
-    -- 3. Injected Environment
-    local env = {
-        require = function(targetPath: string)
-            -- If it's a relative path, resolve it against the CURRENT module's directory
-            if targetPath:sub(1, 1) == "." then
-                local currentDir = fullPath:match("(.*[/\\])") or "./"
-                local resolved = resolvePath(currentDir, targetPath)
-                return LuneFs.loadModule(resolved)
-            end
-            
-            -- Fallback for @lune/ built-ins
-            return require(targetPath) :: any
-        end
-    }
-
-    local fn = luau.load(bytecode, {
-        debugName = fullPath,
-        environment = env,
-        injectGlobals = true,
-    })
-
-    local success, result = pcall(fn)
-    if not success then
-        error(`Failed to load module '{fullPath}':\n{result}`)
-    end
-
-    moduleCache[fullPath] = result
-    return result
 end
 
 return LuneFs

--- a/src/libs/fs/lute.luau
+++ b/src/libs/fs/lute.luau
@@ -1,0 +1,72 @@
+local fs = require("@lute/fs")
+local process = require("@lute/process")
+local Types = require("./types")
+
+local LuteFs = {} :: Types.FsAdapter
+
+local function pathType(path: string): string?
+    local result = process.run({ "test", "-f", path })
+    if result.ok then return "file" end
+    local result2 = process.run({ "test", "-d", path })
+    if result2.ok then return "dir" end
+    return nil
+end
+
+function LuteFs.isFile(path: string)
+    return pathType(path) == "file"
+end
+
+function LuteFs.isDir(path: string)
+    return pathType(path) == "dir"
+end
+
+function LuteFs.readFile(path: string): string
+    local result = process.run({ "cat", path })
+    if result.ok then
+        return result.stdout
+    else
+        return result.stderr
+    end
+end
+
+function LuteFs.writeFile(path: string, contents: string)
+    local ok, err = pcall(function()
+        local handle = fs.open(path, "w")
+        fs.write(handle, contents)
+        fs.close(handle)
+    end)
+    if not ok then
+        error(`Failed to write file '{path}': {err}`)
+    end
+end
+
+function LuteFs.readDir(path: string)
+    local result = process.run({ "ls", "-1", path })
+    if not result.ok then
+        error("Directory not found: " .. path)
+    end
+    local names = {}
+    for name in result.stdout:gmatch("[^\n]+") do
+        table.insert(names, name)
+    end
+    return names
+end
+
+function LuteFs.metadata(path: string)
+    local ok, stat = pcall(fs.stat, path)
+    if not ok then
+        error("Path not found: " .. path)
+    end
+    return {
+        kind = stat.type :: any,
+        exists = true,
+        createdAt = stat.created:toSeconds(),
+        modifiedAt = stat.modified:toSeconds(),
+        accessedAt = stat.accessed:toSeconds(),
+        permissions = {
+            readOnly = stat.permissions.readonly,
+        },
+    }
+end
+
+return LuteFs

--- a/src/libs/fs/types.luau
+++ b/src/libs/fs/types.luau
@@ -1,10 +1,10 @@
 
 export type FsMetadata = {
-    kind: "file" | "dir" | "symlink",
+    kind: "file" | "dir",
     exists: boolean,
-    createdAt: DateTime,
-    modifiedAt: DateTime,
-    accessedAt: DateTime,
+    createdAt: number,
+    modifiedAt: number,
+    accessedAt: number,
     permissions: {
         readOnly: boolean
     }

--- a/src/libs/fs/zune.luau
+++ b/src/libs/fs/zune.luau
@@ -1,5 +1,4 @@
 local fs = zune.fs
-local luau = zune.luau
 local Types = require("./types")
 
 local ZuneFs = {} :: Types.FsAdapter
@@ -32,14 +31,6 @@ end
 
 function ZuneFs.metadata(path: string)
     return fs.metadata(path) :: any
-end
-
-function ZuneFs.loadModule(path: string)
-    local source = fs.readFileSync(path)
-    local bytecode = luau.compile(source)
-    local fn = luau.load(bytecode)
-    print("This is working 4")
-    return fn
 end
 
 return ZuneFs

--- a/src/libs/net/init.luau
+++ b/src/libs/net/init.luau
@@ -14,6 +14,8 @@ local function getAdapter(): Types.NetAdapter
         return require("@self/lune")
     elseif runtime == "zune" then
         return require("@self/zune")
+    elseif runtime == "luau" then
+        return require("@self/lute")
     else
         error(`Unsupported Runtime: "{runtime}"`)
     end

--- a/src/libs/net/lute.luau
+++ b/src/libs/net/lute.luau
@@ -1,21 +1,22 @@
-local http = zune.net.http
+local server = require("@lute/net/server")
+local client = require("@lute/net/client")
 local Types = require("./types")
 local normalizeHeader = require("../normalizeHeader")
 
-local ZuneNet = {} :: Types.NetAdapter
+local LuteNet = {} :: Types.NetAdapter
 
-function ZuneNet.serve(port, handlerOrConfig)
+function LuteNet.serve(port, handlerOrConfig)
     if not (typeof(handlerOrConfig) == "table") then return end
 
-    http.serve({
+    server.serve({
         port = port,
-        address = handlerOrConfig.address,
-        request = function(request)
+        hostname = handlerOrConfig.address,
+        handler = function(request)
             local res = handlerOrConfig.handleRequest(request :: any)
-
+            
             if typeof(res) == "string" then
                 return {
-                    status_code = 200,
+                    status = 200,
                     body = res
                 }
             end
@@ -32,17 +33,18 @@ function ZuneNet.serve(port, handlerOrConfig)
             end
 
             return {
-                status_code = res.status,
+                status = res.status,
                 headers = normalizedHeaders,
-                body = res.body
+                body = res.body :: string
             }
         end
     })
 end
 
-function ZuneNet.request(config: Types.FetchParams | string)
+function LuteNet.request(config)
+    
     if typeof(config) == "table" and config.url then
-        return http.request(config.url, {
+        return client.request(config.url, {
             headers = config.headers,
             method = config.method,
             body = config.body,
@@ -50,7 +52,7 @@ function ZuneNet.request(config: Types.FetchParams | string)
         }) :: any
     end
 
-    return http.request(config)
+    return client.request(config)
 end
 
-return ZuneNet
+return LuteNet

--- a/src/libs/process/init.luau
+++ b/src/libs/process/init.luau
@@ -8,6 +8,8 @@ local function getAdapter(): Types.ProcessAdapter
         return require("@self/lune")
     elseif runtime == "zune" then
         return require("@self/zune")
+    elseif runtime == "luau" then
+        return require("@self/lute")
     else
         error(`Unsupported Runtime: "{runtime}"`)
     end

--- a/src/libs/process/lute.luau
+++ b/src/libs/process/lute.luau
@@ -1,0 +1,17 @@
+local process = require("@lute/process")
+local Types = require("./types")
+
+local LuteProcess = {} :: Types.ProcessAdapter
+
+LuteProcess.cwd = process.cwd() .. "/"
+LuteProcess.env = process.env :: { [string]: string? }
+
+function LuteProcess.create(exec, args, opts: ProcessOptions?): ProcessChild?
+    if not args then 
+        return nil
+    end
+
+    return process.run({ exec, args[1], args[2] }, opts) :: any
+end
+
+return LuteProcess

--- a/src/libs/process/types.luau
+++ b/src/libs/process/types.luau
@@ -20,7 +20,7 @@ export type ProcessChild = {
 export type ProcessAdapter = {
     cwd: string,
     env: { [string]: string? },
-    create: (exec: string, args: { string }?, opts: ProcessOptions?) -> ProcessChild,
+    create: (exec: string, args: { string }?, opts: ProcessOptions?) -> ProcessChild?,
 }
 
 return {}

--- a/src/libs/serde/init.luau
+++ b/src/libs/serde/init.luau
@@ -8,6 +8,8 @@ local function getAdapter(): Types.SerdeAdapter
         return require("@self/lune")
     elseif runtime == "zune" then
         return require("@self/zune")
+    elseif runtime == "luau" then
+        return require("@self/lute")
     else
         error(`Unsupported Runtime: "{runtime}"`)
     end

--- a/src/libs/serde/lute.luau
+++ b/src/libs/serde/lute.luau
@@ -1,0 +1,22 @@
+local json = require("@std/json")
+local Types = require("./types")
+
+local LuneSerde = {} :: Types.SerdeAdapter
+
+function LuneSerde.decode(format, encoded)
+    if not (format == "json") then
+        error("Unsupported format: " .. format)
+    end
+
+    return json.deserialize(encoded)
+end
+
+function LuneSerde.encode(format, value, pretty)
+    if not (format == "json") then
+        error("Unsupported format: " .. format)
+    end
+
+    return json.serialize(value, pretty)
+end
+
+return LuneSerde

--- a/src/libs/task/init.luau
+++ b/src/libs/task/init.luau
@@ -8,6 +8,8 @@ local function getAdapter(): Types.TaskAdapter
         return require("@self/lune")
     elseif runtime == "zune" then
         return require("@self/zune")
+    elseif runtime == "luau" then
+        return require("@self/lute")
     else
         error(`Unsupported Runtime: "{runtime}"`)
     end

--- a/src/libs/task/lute.luau
+++ b/src/libs/task/lute.luau
@@ -1,0 +1,10 @@
+local task = require("@lute/task")
+local Types = require("./types")
+
+local LuneTask = {} :: Types.TaskAdapter
+
+function LuneTask.wait(duration)
+    return task.wait(duration)
+end
+
+return LuneTask

--- a/src/utils/generateAlias.luau
+++ b/src/utils/generateAlias.luau
@@ -15,7 +15,6 @@ local function generateAlias()
 
     local encode = serde.encode("json", decode, true)
     decode.aliases.c = process.cwd
-    print(`[debug] writing @c = "{decode.aliases.c}"`)
     fs.writeFile(luaurcPath, encode)
 end
 

--- a/src/utils/loadEnv.luau
+++ b/src/utils/loadEnv.luau
@@ -3,7 +3,7 @@ local fs = require("../libs/fs")
 
 local function loadEnv()
     local envVars = {}
-    local success, content: string = pcall(fs.readFile, ".env" or ".env.local" or ".env.development")
+    local success, content = pcall(fs.readFile, ".env" or ".env.local" or ".env.development")
     
     if success then
         for line in content:gmatch("[^\r\n]+") do

--- a/zune.toml
+++ b/zune.toml
@@ -1,11 +1,11 @@
 # Zune Configuration
 
 [workspace]
-cwd = "ci"
+cwd = "."
  
 [workspace.scripts]
-start = "src/index"
-test = "tests/zune"
+start = ".zune/start"
+test = ".zune/test"
 
 [runtime.debug]
 detailed_error = true


### PR DESCRIPTION
Implement Lute adapters for `fs`, `net`, `process`, `serde`, and `task` libraries.
Integrate Lute into CI workflows and configuration.
Add Lute-specific startup and testing scripts in `.lute/`.
Update `ci/` modules to use `@nova` aliases for better portability.
Refactor `FsMetadata` types for better cross-runtime compatibility.