### PR TITLE
feat(tests): implement custom test runner and add initial unit tests

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -4,12 +4,11 @@
         "warn"
     ], 
     "aliases": {
-        "pesde": "lune_packages/", 
         "std": "~/.lute/typedefs/1.0.0/std", 
-        "c": "/home/wiz/projects/nova-projects/core/ci/", 
         "lint": "~/.lute/typedefs/1.0.0/lint", 
-        "nova": "./ci/src/", 
         "lune": "~/.lune/.typedefs/0.10.4/", 
-        "lute": "~/.lute/typedefs/1.0.0/lute"
+        "lute": "~/.lute/typedefs/1.0.0/lute",
+        "src": "./src/",
+        "test-runner": "./tests/runner"
     }
 }

--- a/.lune/test.luau
+++ b/.lune/test.luau
@@ -1,0 +1,3 @@
+local process = require("@lune/process")
+
+process.exec("lune", { "run", "tests" }, { stdio = "inherit" })

--- a/.lute/test.luau
+++ b/.lute/test.luau
@@ -1,0 +1,3 @@
+local process = require("@lute/process")
+
+process.run({ "lute", "run", "tests" }, { stdio = "inherit" })

--- a/.zune/test.luau
+++ b/.zune/test.luau
@@ -1,0 +1,3 @@
+local process = zune.process
+
+process.run("zune", { "run", "tests" }, { stdout = "inherit", stderr = "inherit" })

--- a/src/core/routing.luau
+++ b/src/core/routing.luau
@@ -197,7 +197,68 @@ local function routerDispatcher(request: Types.Request)
     return handler(req)
 end
 
+local function createTestRouter()
+    local staticRoutes: { [string]: any } = {}
+    local root: RouteNode = { children = {} }
+
+    return {
+        registerRoute = function(path: string, module: any)
+            if not string.find(path, "%[") then
+                staticRoutes[path] = module
+                return
+            end
+
+            local segments = splitPath(path)
+            local currentNode = root
+
+            for _, segment in ipairs(segments) do
+                if string.byte(segment, 1) == 91 and string.byte(segment, -1) == 93 then
+                    local paramName = string.sub(segment, 2, -2)
+
+                    if string.sub(paramName, 1, 3) == "..." then
+                        local cleanName = string.sub(paramName, 4)
+                        if not currentNode.wildcardChild then
+                            currentNode.wildcardChild = createNode()
+                            currentNode.wildcardName = cleanName
+                        end
+                        currentNode = currentNode.wildcardChild :: RouteNode
+                    else
+                        if not currentNode.dynamicChild then
+                            currentNode.dynamicChild = createNode()
+                            currentNode.dynamicName = paramName
+                        end
+                        currentNode = currentNode.dynamicChild :: RouteNode
+                    end
+                else
+                    if not currentNode.children[segment] then
+                        currentNode.children[segment] = createNode()
+                    end
+                    currentNode = currentNode.children[segment]
+                end
+            end
+
+            currentNode.module = module
+        end,
+
+        matchRoute = function(path: string, params: { [string]: any })
+            local cleanPath = path
+            if #cleanPath > 1 and string.byte(cleanPath, -1) == 47 then
+                cleanPath = string.sub(cleanPath, 1, -2)
+            end
+
+            if staticRoutes[cleanPath] then
+                return staticRoutes[cleanPath]
+            end
+
+            local segments = splitPath(cleanPath)
+            local node = matchRouteFrom(root, segments, 1, params)
+            return node and node.module or nil
+        end
+    }
+end
+
 return { 
     registerRoute = registerRoute, 
-    routerDispatcher = routerDispatcher 
+    routerDispatcher = routerDispatcher,
+    createTestRouter = createTestRouter
 }

--- a/src/libs/fs/types.luau
+++ b/src/libs/fs/types.luau
@@ -16,8 +16,7 @@ export type FsAdapter = {
     writeFile: (path: string, contents: buffer | string) -> (),
     isDir: (path: string) -> boolean,
     readDir: (path: string) -> {string},
-    metadata: (path: string) -> FsMetadata,
-    loadModule: (path: string) -> any
+    metadata: (path: string) -> FsMetadata
 }
 
 return {}

--- a/src/libs/process/lune.luau
+++ b/src/libs/process/lune.luau
@@ -11,4 +11,8 @@ function LuneProcess.create(exec, args, opts)
     return process.create(exec, args, opts) :: any
 end
 
+function LuneProcess.exit(code)
+    process.exit(code)
+end
+
 return LuneProcess

--- a/src/libs/process/lute.luau
+++ b/src/libs/process/lute.luau
@@ -11,14 +11,18 @@ function LuteProcess.create(exec, args, opts: ProcessOptions?): ProcessChild?
         return nil
     end
 
-    local query = table.concat(args, " ")
-    query = `{exec} {query}`
+    -- local query = table.concat(args, " ")
+    -- query = `{exec} {query}`
     
-    return process.run({"sh", 
-        "-c", 
-        `{query} &`
-    }, opts) :: any
-    --return process.run({ exec, args[1], args[2] }, opts) :: any
+    -- return process.run({"sh", 
+    --     "-c", 
+    --     `{query} &`
+    -- }, opts) :: any
+    return process.run({ exec, args[1], args[2] }, opts :: any) :: any
+end
+
+function LuteProcess.exit(code)
+    process.exit(code)
 end
 
 return LuteProcess

--- a/src/libs/process/types.luau
+++ b/src/libs/process/types.luau
@@ -21,6 +21,7 @@ export type ProcessAdapter = {
     cwd: string,
     env: { [string]: string? },
     create: (exec: string, args: { string }?, opts: ProcessOptions?) -> ProcessChild?,
+    exit: (number) -> ()
 }
 
 return {}

--- a/src/libs/process/zune.luau
+++ b/src/libs/process/zune.luau
@@ -11,4 +11,8 @@ function ZuneProcess.create(exec, args, opts)
     return process.create(exec, args, opts)
 end
 
+function ZuneProcess.exit(code)
+    process.exit(code)
+end
+
 return ZuneProcess

--- a/tests/adapters/fs/fs.test.luau
+++ b/tests/adapters/fs/fs.test.luau
@@ -1,0 +1,74 @@
+local runner = require("@test-runner")
+local fs = require("@src/libs/fs")
+
+local FIXTURES = "./tests/fixtures/fs"
+
+local describe, test, expect = runner.describe, runner.test, runner.expect
+
+local function Test()
+    describe("isFile", function()
+        test("returns true for an existing file", function()
+            local result = fs.isFile(FIXTURES .. "/hello.txt")
+            expect(result).toBe(true)
+        end)
+
+        test("returns false for a directory", function()
+            local result = fs.isFile(FIXTURES .. "/subdir")
+            expect(result).toBe(false)
+        end)
+
+        test("returns false for a nonexistent path, never throws", function()
+            local ok, result = pcall(fs.isFile, FIXTURES .. "/does-not-exist.txt")
+            expect(ok).toBe(true)
+            expect(result).toBe(false)
+        end)
+    end)
+
+    describe("isDir", function()
+        test("returns true for an existing directory", function()
+            local result = fs.isDir(FIXTURES .. "/subdir")
+            expect(result).toBe(true)
+        end)
+
+        test("returns false for a file", function()
+            local result = fs.isDir(FIXTURES .. "/hello.txt")
+            expect(result).toBe(false)
+        end)
+
+        test("returns false for a nonexistent path, never throws", function()
+            local ok, result = pcall(fs.isDir, FIXTURES .. "/does-not-exist")
+            expect(ok).toBe(true)
+            expect(result).toBe(false)
+        end)
+    end)
+
+    describe("readFile", function()
+        test("returns the file contents as a string", function()
+            local result = fs.readFile(FIXTURES .. "/hello.txt")
+            expect(type(result)).toBe("string")
+        end)
+    end)
+
+    describe("readDir", function()
+        test("returns a table of entry names", function()
+            local result = fs.readDir(FIXTURES)
+            expect(type(result)).toBe("table")
+        end)
+
+        test("includes known entries", function()
+            local result = fs.readDir(FIXTURES)
+            local found = false
+            for _, name in result do
+                if name == "hello.txt" then
+                    found = true
+                    break
+                end
+            end
+            expect(found).toBe(true)
+        end)
+    end)
+
+    runner.summary()
+end
+
+return Test

--- a/tests/fixtures/fs/hello.txt
+++ b/tests/fixtures/fs/hello.txt
@@ -1,0 +1,1 @@
+"Hello, World"

--- a/tests/init.luau
+++ b/tests/init.luau
@@ -1,0 +1,30 @@
+local fs = require("@src/libs/fs")
+local runner = require("@self/runner")
+
+local function findTestFiles(dir: string): { string }
+    local results = {}
+
+    for _, entry in fs.readDir(dir) do
+        local fullPath = dir .. "/" .. entry
+
+        if fs.isDir(fullPath) then
+            for _, nested in findTestFiles(fullPath) do
+                table.insert(results, nested)
+            end
+        elseif string.match(entry, "%.test%.luau$") then
+            table.insert(results, fullPath)
+        end
+    end
+
+    return results
+end
+
+local files = findTestFiles("tests")
+
+for _, file in files do
+    local modulePath = string.match(file, "^(.-)%.luau$")
+    print("\27[1;36m\n[ " .. file .. " ]\n\27[0m")
+    runner.reset()
+    local testFn = require(`./{modulePath}`) :: any
+    testFn()
+end

--- a/tests/runner.luau
+++ b/tests/runner.luau
@@ -1,0 +1,118 @@
+local process = require("../src/libs/process")
+
+export type Expected = {
+    toBe: (expected: any) -> (),
+    toEqual: (expected: any) -> (),
+    toBeNil: (expected: any) -> (),
+    never: (expected: any) -> (),
+}
+
+export type TestRunner = {
+    describe: (name: string, fn: () -> ()) -> (),
+    test: (name: string, fn: () -> ()) -> (),
+    summary: () -> (),
+    expect: (any) -> Expected,
+    reset: () -> ()
+}
+
+local passed = 0
+local failed = 0
+local errors = {}
+
+local function expect(value: any)
+    return {
+        toBe = function(expected: any)
+            if value ~= expected then
+                error(
+                    `expected {tostring(expected)}, got {tostring(value)}`,
+                    2
+                )
+            end
+        end,
+        toEqual = function(expected: any)
+            -- deep equality for tables
+            local function deepEqual(a, b)
+                if type(a) ~= type(b) then return false end
+                if type(a) ~= "table" then return a == b end
+                for k, v in a do
+                    if not deepEqual(v, b[k]) then return false end
+                end
+                for k in b do
+                    if a[k] == nil then return false end
+                end
+                return true
+            end
+            if not deepEqual(value, expected) then
+                error(
+                    `expected {tostring(expected)}, got {tostring(value)}`,
+                    2
+                )
+            end
+        end,
+        toBeNil = function()
+            if value ~= nil then
+                error(`expected nil, got {tostring(value)}`, 2)
+            end
+        end,
+        never = {
+            toBeNil = function()
+                if value == nil then
+                    error("expected a value, got nil", 2)
+                end
+            end
+        }
+    }
+end
+
+local currentSuite = ""
+
+local function describe(name: string, fn: () -> ())
+    currentSuite = name
+    fn()
+    currentSuite = ""
+end
+
+local function test(name: string, fn: () -> ())
+    local label = if currentSuite ~= "" then `{currentSuite} > {name}` else name
+    local ok, err = pcall(fn)
+    if ok then
+        passed += 1
+        print("\27[32m" .. "  ✓ " .. "\27[0m" .. label)
+    else
+        failed += 1
+        table.insert(errors, { label = label, message = tostring(err) })
+        print("\27[31m" .. "  ✗ " .. "\27[0m" .. label)
+    end
+end
+
+local function summary()
+    if #errors > 0 then
+        print("\n\27[31m" .. "Failures:\n" .. "\27[0m")
+        for _, e in errors do
+            print(`  {e.label}\n    {e.message}`)
+        end
+    end
+    print(
+        "\n\27[32m" .. `{passed} passed` .. "\27[0m" ..
+        ", " ..
+        "\27[31m" .. `{failed} failed` .. "\27[0m"
+    )
+    
+    if failed > 0 then
+        process.exit(1)
+    end
+end
+
+local function reset()
+    passed = 0
+    failed = 0
+    errors = {}
+end
+
+return { 
+    describe = describe, 
+    test = test, 
+    expect = expect, 
+    summary = summary, 
+    reset = reset 
+}

--- a/tests/unit/router.test.luau
+++ b/tests/unit/router.test.luau
@@ -1,0 +1,110 @@
+local runner = require("../../tests/runner")
+local describe, test, expect = runner.describe, runner.test, runner.expect
+
+local createRouter = require("../../src/core/routing").createTestRouter
+
+local function Test()
+    describe("static routes", function()
+        test("matches an exact path", function()
+            local router = createRouter()
+            local module = { Get = function() end }
+            router.registerRoute("/hello", module)
+
+            local params = {}
+            local matched = router.matchRoute("/hello", params)
+            expect(matched).toBe(module)
+        end)
+
+        test("returns nil for unregistered path", function()
+            local router = createRouter()
+            local params = {}
+            local matched = router.matchRoute("/nope", params)
+            expect(matched).toBeNil()
+        end)
+
+        test("strips trailing slash before matching", function()
+            local router = createRouter()
+            local module = { Get = function() end }
+            router.registerRoute("/hello", module)
+
+            local params = {}
+            local matched = router.matchRoute("/hello/", params)
+            expect(matched).toBe(module)
+        end)
+    end)
+
+    describe("dynamic routes", function()
+        test("matches a single dynamic segment and extracts param", function()
+            local router = createRouter()
+            local module = { Get = function() end }
+            router.registerRoute("/user/[id]", module)
+
+            local params = {}
+            local matched = router.matchRoute("/user/42", params)
+            expect(matched).toBe(module)
+            expect(params.id).toBe("42")
+        end)
+
+        test("matches nested dynamic segments", function()
+            local router = createRouter()
+            local module = { Get = function() end }
+            router.registerRoute("/user/[id]/post/[postId]", module)
+
+            local params = {}
+            local matched = router.matchRoute("/user/5/post/99", params)
+            expect(matched).toBe(module)
+            expect(params.id).toBe("5")
+            expect(params.postId).toBe("99")
+        end)
+
+        test("does not match when segment count differs", function()
+            local router = createRouter()
+            local module = { Get = function() end }
+            router.registerRoute("/user/[id]", module)
+
+            local params = {}
+            local matched = router.matchRoute("/user/42/extra", params)
+            expect(matched).toBeNil()
+        end)
+
+        test("static segment takes priority over dynamic", function()
+            local router = createRouter()
+            local staticModule = { Get = function() end }
+            local dynamicModule = { Get = function() end }
+            router.registerRoute("/user/me", staticModule)
+            router.registerRoute("/user/[id]", dynamicModule)
+
+            local params = {}
+            local matched = router.matchRoute("/user/me", params)
+            expect(matched).toBe(staticModule)
+        end)
+    end)
+
+    describe("wildcard routes", function()
+        test("matches remaining segments as a table", function()
+            local router = createRouter()
+            local module = { Get = function() end }
+            router.registerRoute("/files/[...path]", module)
+
+            local params = {}
+            local matched = router.matchRoute("/files/a/b/c", params)
+            expect(matched).toBe(module)
+            expect(params.path).toEqual({ "a", "b", "c" })
+        end)
+
+        test("matches with zero remaining segments", function()
+            local router = createRouter()
+            local module = { Get = function() end }
+            router.registerRoute("/files/[...path]", module)
+
+            local params = {}
+            local matched = router.matchRoute("/files", params)
+            expect(matched).toBe(module)
+            expect(params.path).toEqual({})
+        end)
+    end)
+
+    runner.summary()
+end
+
+return Test

--- a/zune.toml
+++ b/zune.toml
@@ -1,0 +1,23 @@
+# Zune Configuration
+
+[workspace]
+cwd = "."
+ 
+[workspace.scripts]
+start = ".zune/start"
+test = ".zune/test"
+
+[runtime.debug]
+detailed_error = true
+
+[runtime.luau.options]
+debug_level = 2
+optimization_level = 1
+native_code_gen = true
+
+[resolvers.formatter]
+max_depth = 4
+use_color = true
+table_address = true
+recursive_Table = false
+buffer_max_display = 48


### PR DESCRIPTION
- Implement a lightweight test runner with `describe`, `test`, and `expect` utilities.
- Add cross-runtime test scripts (`.lune/test.luau`, `.lute/test.luau`, `.zune/test.luau`) for unified testing.
- Add unit tests for the router and fs adapter, including file fixtures.
- Update process adapters across all runtimes to support the `exit(code)` method.
- Export `createTestRouter` in `routing.luau` to facilitate isolated testing of the routing engine.
- Configure `zune.toml` and update `.luaurc` with path aliases for the source and test runner.