### PR TITLE
feat: add web test suite

### DIFF
--- a/.lune/start.luau
+++ b/.lune/start.luau
@@ -1,0 +1,22 @@
+local process = require("@lune/process")
+local serde = require("../src/libs/serde")
+local fs = require("../src/libs/fs")
+
+local luaurcPath = process.cwd .. ".luaurc"
+local luaurcjson = fs.readFile(luaurcPath)
+local decode = serde.decode("json", luaurcjson)
+
+if not decode.aliases then
+    decode.aliases = {}
+end
+
+local newCAlias = process.cwd .. "tests/web/"
+
+if not (newCAlias == decode.aliases.c) then
+    decode.aliases.c = newCAlias
+end
+
+local encode = serde.encode("json", decode, true)
+fs.writeFile(luaurcPath, encode)
+
+process.exec("lune", { "run", "src/main" }, { stdio = "inherit", cwd = "tests/web" })

--- a/.lute/start.luau
+++ b/.lute/start.luau
@@ -1,0 +1,22 @@
+local process = require("@lute/process")
+local serde = require("../src/libs/serde")
+local fs = require("../src/libs/fs")
+
+local luaurcPath = process.cwd() .. "/.luaurc"
+local luaurcjson = fs.readFile(luaurcPath)
+local decode = serde.decode("json", luaurcjson)
+
+if not decode.aliases then
+    decode.aliases = {}
+end
+
+local newCAlias = process.cwd() .. "/tests/web/"
+
+if not (newCAlias == decode.aliases.c) then
+    decode.aliases.c = newCAlias
+end
+
+local encode = serde.encode("json", decode, true)
+fs.writeFile(luaurcPath, encode)
+
+process.run({ "lute", "run", "src/main" }, { stdio = "inherit", cwd = "tests/web" })

--- a/.zune/start.luau
+++ b/.zune/start.luau
@@ -1,0 +1,23 @@
+local process = zune.process
+local serde = require("../src/libs/serde")
+local fs = require("../src/libs/fs")
+
+local luaurcPath = process.cwd() .. "/.luaurc"
+local luaurcjson = fs.readFile(luaurcPath)
+local decode = serde.decode("json", luaurcjson)
+
+if not decode.aliases then
+    decode.aliases = {}
+end
+
+local newCAlias = process.cwd() .. "/tests/web/"
+
+if not (newCAlias == decode.aliases.c) then
+    decode.aliases.c = newCAlias
+end
+
+local encode = serde.encode("json", decode, true)
+fs.writeFile(luaurcPath, encode)
+
+
+process.run("zune", { "run", "src/main" }, { stderr = "inherit", stdout = "inherit", cwd = "tests/web" })

--- a/src/libs/serde/zune.luau
+++ b/src/libs/serde/zune.luau
@@ -32,7 +32,7 @@ function LuneSerde.encode(format, value, pretty)
         error(`Unsupported format: "{format}"`)
     end
 
-    return encoder(value)
+    return encoder(value, { pretty_indent = 2 })
 end
 
 return LuneSerde

--- a/src/types.luau
+++ b/src/types.luau
@@ -47,7 +47,7 @@ export type Response = {
     --[[
         Respond with a json
     ]]
-    json: (body: {any}, config: ResponseOptions?) -> ResponsePayload,
+    json: <T>(body: T, config: ResponseOptions?) -> ResponsePayload,
 
     --[[
         Respond with an html

--- a/tests/web/.luaurc
+++ b/tests/web/.luaurc
@@ -1,15 +1,11 @@
 {
-    "languageMode": "strict",
-    "globals": [
-        "warn"
-    ],
     "aliases": {
-        "src": "./src/",
+        "std": "~/.lute/typedefs/1.0.0/std",
         "c": "/home/wiz/projects/nova-projects/nova/tests/web/",
         "lint": "~/.lute/typedefs/1.0.0/lint",
-        "test-runner": "./tests/runner",
-        "std": "~/.lute/typedefs/1.0.0/std",
+        "nova": "../../src/index",
         "lune": "~/.lune/.typedefs/0.10.4/",
+        "pkg": "./lune_packages/",
         "lute": "~/.lute/typedefs/1.0.0/lute"
     }
 }

--- a/tests/web/src/app/[...ids]/route.luau
+++ b/tests/web/src/app/[...ids]/route.luau
@@ -1,0 +1,10 @@
+local Nova = require("@nova")
+
+local Home = {}
+
+function Home.Get(req: Nova.RequestWith<{ ids: { string } }>)
+    local userIds = req.params.ids
+    return Nova.response.json({ userIds = userIds, msg = "Found user IDs" })
+end
+
+return Home

--- a/tests/web/src/app/[id]/route.luau
+++ b/tests/web/src/app/[id]/route.luau
@@ -1,0 +1,10 @@
+local Nova = require("@nova")
+
+local Home = {}
+
+function Home.Get(banana: Nova.RequestWith<{ id: string }>)
+    local userId = banana.params.id
+    return Nova.response.json({ userId = userId, msg = "Found a user ID" })
+end
+
+return Home

--- a/tests/web/src/app/route.luau
+++ b/tests/web/src/app/route.luau
@@ -1,0 +1,9 @@
+local Nova = require("@nova")
+
+local Home = {}
+
+function Home.Get()
+    return Nova.response.json("Hello, World")
+end
+
+return Home

--- a/tests/web/src/app/users/route.luau
+++ b/tests/web/src/app/users/route.luau
@@ -1,0 +1,10 @@
+local Nova = require("@nova")
+local UserService = require("./users.service")
+
+local Users = {}
+
+function Users.Get()
+    return Nova.response.json(UserService.getUser(123))
+end
+
+return Users

--- a/tests/web/src/app/users/users.service.luau
+++ b/tests/web/src/app/users/users.service.luau
@@ -1,0 +1,9 @@
+local UserService = {}
+
+function UserService.getUser(userId: number)
+    return {
+        msg = "Hello, user " .. userId
+    }
+end
+
+return UserService

--- a/tests/web/src/main.luau
+++ b/tests/web/src/main.luau
@@ -1,0 +1,10 @@
+local Nova = require("@nova")
+local process = require("../../../src/libs/process")
+--local process = zune.process
+
+local PORT = tonumber(process.env.PORT) or 8080
+local app = Nova.new(PORT)
+
+app:listen(function()
+    print(`Nova is running on Port {PORT}`)
+end)


### PR DESCRIPTION
- Implement a comprehensive web application for testing in `tests/web`, including dynamic (`[id]`) and catch-all (`[...ids]`) routing.
- Add runtime-specific start scripts (`.lune/start.luau`, `.lute/start.luau`, `.zune/start.luau`) to automate `.luaurc` configuration and project execution.
- Enhance `Response.json` type definition in `src/types.luau` to be generic for improved type safety.
- Enable pretty-printing for JSON serialization in the Zune runtime adapter.
- Update root `.luaurc` with workspace aliases to support the new test structure.